### PR TITLE
spelling error

### DIFF
--- a/pynite/errors.py
+++ b/pynite/errors.py
@@ -41,7 +41,7 @@ class NoGames(BaseError):
         super().__init__(self.code, self.error)
 
 
-class UnkownError(BaseError):
+class UnknownError(BaseError):
     '''Raised when an unknown case or error has occured.'''
 
     def __init__(self, mode):


### PR DESCRIPTION
the error is spelt correctly everywhere else, other than where it is defined